### PR TITLE
Fixed a docstring. Fixed missing preview image bug causing an error.

### DIFF
--- a/src/tools/Asset/AssetManager/src/util/asset_manager_utils.py
+++ b/src/tools/Asset/AssetManager/src/util/asset_manager_utils.py
@@ -160,12 +160,10 @@ def get_asset_creation_details(tool_object: QMainWindow, is_publish: bool = Fals
 
     Returns:
         dict: Asset details as follows:
-        {
-            "asset_category" (str): Name of Asset Category,
+            {"asset_category" (str): Name of Asset Category,
             "asset_name" (str): Name of Asset,
             "asset_variant" (str): Name of Asset Variant,
-            "file_path" (str): File path if chosen. Otherwise is None
-        }
+            "file_path" (str): File path if chosen. Otherwise is None.}
     """
     asset_details = {
         "asset_category": tool_object.root.cbo_apb_asset_type.currentText(),

--- a/src/tools/Asset/AssetManager/src/util/valkyrie_asset.py
+++ b/src/tools/Asset/AssetManager/src/util/valkyrie_asset.py
@@ -6,11 +6,19 @@ import os
 from pathlib import PurePath
 import re
 
+from Core import core_paths as cpath
 from Core.util import file_util_tools as fut
 from Core.util import project_util_tools as prj
 
 
 LOG = logging.getLogger(os.path.basename(__file__))
+
+# Current Module root path
+MODULE_PATH = f"{cpath.get_parent_directory(__file__, 2)}"
+
+# Full path to where resource files are stored
+RSRC_PATH = f"{MODULE_PATH}/resources"
+NO_PREVIEW_IMAGE_PATH = f"{RSRC_PATH}/images/Select_file_preview.png"
 
 PROJECT_CONFIGS = prj.get_project_configs()
 
@@ -222,6 +230,7 @@ class ValkyrieAsset:
         self.set_asset_metadata_path(
             PurePath(asset_path, f"{asset_name}_metadata.json")
         )
+        self.set_asset_preview_path(NO_PREVIEW_IMAGE_PATH)
 
     def set_asset_name(self, new_name: str):
         """Set Asset's name.


### PR DESCRIPTION
Fixed a bug/error caused when a Maya Asset created with the Asset Manager doesn't have any published files and only has APB/wip files. Initially prevented tool from launching entirely. Now defaults to a No Preview Image when a valid Asset preview image isn't found.